### PR TITLE
Migrate to Swift 2.3

### DIFF
--- a/MBDrawingView.swift
+++ b/MBDrawingView.swift
@@ -92,7 +92,11 @@ public class MBDrawingView: UIView {
         CGContextAddLineToPoint(context, point.x, point.y)
         CGContextStrokePath(context)
 
-        let image = UIGraphicsGetImageFromCurrentImageContext()
+        #if swift(>=2.3)
+            let image = UIGraphicsGetImageFromCurrentImageContext()!
+        #else
+            let image = UIGraphicsGetImageFromCurrentImageContext()
+        #endif
 
         layer.contents = image.CGImage
     }


### PR DESCRIPTION
`UIGraphicsGetImageFromCurrentImageContext()` now returns an optional in Xcode 8 / iOS 10 SDK / Swift 2.3.

/cc @friedbunny @incanus
